### PR TITLE
Allowing Custom Species access to DSI - Teshari prosthetic limbs.

### DIFF
--- a/code/modules/organs/robolimbs_vr.dm
+++ b/code/modules/organs/robolimbs_vr.dm
@@ -204,6 +204,7 @@
 /datum/robolimb/dsi_teshari/New()
 	species_cannot_use = GLOB.all_species.Copy()
 	species_cannot_use -= SPECIES_TESHARI
+	species_cannot_use -= SPECIES_CUSTOM
 	..()
 
 /obj/item/weapon/disk/limb/dsi_teshari


### PR DESCRIPTION
Since Teshari are allowed to be created as a custom race to begin with, I'm not seeing too many issues with this change.

Tested on local and the main thing to note is that the user has to choose Icon Base as Teshari to avoid any weirdness with gear, otherwise works as expected.